### PR TITLE
Allow perl blocks in pages

### DIFF
--- a/lib/App/Dapper.pm
+++ b/lib/App/Dapper.pm
@@ -398,6 +398,7 @@ sub render {
             'smart' => \&App::Dapper::Filters::smart,
             'json' => \&App::Dapper::Filters::json,
         },
+        EVAL_PERL => $ENV{EVAL_PERL} || 0,
         #DEBUG => DEBUG_ALL,
     }) || die "$Template::ERROR\n";        
 


### PR DESCRIPTION
Using EVAL_PERL in TT is not recommended but I believe its extremely useful for dapper since its a static page generator more than a library.

If dapper supports perl blocks in pages, it will gain superior power of perl and you can basically do _anything_ with it.

This patch is activating EVAL_PERL if environment variable is set.
