### PR TITLE
Make serving requests faster

### DIFF
--- a/lib/App/Dapper.pm
+++ b/lib/App/Dapper.pm
@@ -463,7 +463,7 @@ sub serve {
 
     $port = $DEFAULT_PORT unless $port;
 
-    my $s = HTTP::Server::Brick->new(port=>$port);
+    my $s = HTTP::Server::Brick->new(port=>$port,fork=>1);
     $s->add_type('text/html' => qw(^[^\.]+$));
     $s->mount("/"=>{ path => $self->{output} });
 


### PR DESCRIPTION
Even on a page with 5 assets (CSS, JS, image) the `dapper serve` command is very slow.
