### PR TITLE
Init template encoding upgrade.

### DIFF
--- a/lib/App/Dapper/Init.pm
+++ b/lib/App/Dapper/Init.pm
@@ -37,7 +37,7 @@ my $templates_index_content = <<'TEMPLATES_INDEX_CONTENT';
 <html>
 <head>
   <title>[% page.title %]</title>
-  <meta http-equiv="content-type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 </head>
 
 <body>


### PR DESCRIPTION
This will fix the content display for all non-latin languages.
